### PR TITLE
Fix edge-to-edge issue

### DIFF
--- a/android/app/src/main/java/network/mysterium/provider/ui/main/MainActivity.kt
+++ b/android/app/src/main/java/network/mysterium/provider/ui/main/MainActivity.kt
@@ -3,11 +3,13 @@ package network.mysterium.provider.ui.main
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.core.view.WindowCompat
 import network.mysterium.node.analytics.NodeAnalytics
 import network.mysterium.node.analytics.event.AnalyticsEvent
 import network.mysterium.provider.ui.navigation.AppNavigation
@@ -21,6 +23,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         window.decorView
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         analytics.trackEvent(AnalyticsEvent.AppLaunchEvent)
         setContent {

--- a/android/app/src/main/java/network/mysterium/provider/ui/screens/home/HomeScreen.kt
+++ b/android/app/src/main/java/network/mysterium/provider/ui/screens/home/HomeScreen.kt
@@ -8,10 +8,14 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -58,6 +62,9 @@ fun HomeScreenContent(
     onNavigate: (NavigationDestination) -> Unit
 ) {
     LogoScreenContent(
+        modifier = Modifier
+            .windowInsetsPadding(WindowInsets.statusBars)
+            .windowInsetsPadding(WindowInsets.navigationBars),
         navTrailing = {
             SettingsButton {
                 onNavigate(NavigationDestination.Settings())

--- a/android/app/src/main/java/network/mysterium/provider/ui/screens/launch/LaunchScreen.kt
+++ b/android/app/src/main/java/network/mysterium/provider/ui/screens/launch/LaunchScreen.kt
@@ -15,8 +15,12 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -63,9 +67,10 @@ fun LaunchScreen(
                 } else {
                     val pm: PowerManager? = context.getSystemService(POWER_SERVICE) as PowerManager?
                     if (pm?.isIgnoringBatteryOptimizations(context.packageName) == false) {
-                        batteryOptimization.launch(Intent()
-                            .setAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
-                            .setData(Uri.parse("package:${context.packageName}"))
+                        batteryOptimization.launch(
+                            Intent()
+                                .setAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
+                                .setData(Uri.parse("package:${context.packageName}"))
                         )
                     } else {
                         viewModel.setEvent(Launch.Event.InitializeNode)
@@ -80,9 +85,10 @@ fun LaunchScreen(
         rememberPermissionState(permission = Manifest.permission.POST_NOTIFICATIONS) {
             val pm: PowerManager? = context.getSystemService(POWER_SERVICE) as PowerManager?
             if (pm?.isIgnoringBatteryOptimizations(context.packageName) == false) {
-                batteryOptimization.launch(Intent()
-                    .setAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
-                    .setData(Uri.parse("package:${context.packageName}"))
+                batteryOptimization.launch(
+                    Intent()
+                        .setAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
+                        .setData(Uri.parse("package:${context.packageName}"))
                 )
             } else {
                 viewModel.setEvent(Launch.Event.InitializeNode)
@@ -106,9 +112,10 @@ fun LaunchScreen(
                             val pm: PowerManager? =
                                 context.getSystemService(POWER_SERVICE) as PowerManager?
                             if (pm?.isIgnoringBatteryOptimizations(context.packageName) == false) {
-                                batteryOptimization.launch(Intent()
-                                    .setAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
-                                    .setData(Uri.parse("package:${context.packageName}"))
+                                batteryOptimization.launch(
+                                    Intent()
+                                        .setAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
+                                        .setData(Uri.parse("package:${context.packageName}"))
                                 )
                             } else {
                                 viewModel.setEvent(Launch.Event.InitializeNode)
@@ -141,6 +148,8 @@ private fun LaunchContent(
     Box(
         modifier = Modifier
             .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.statusBars)
+            .windowInsetsPadding(WindowInsets.navigationBars)
             .background(Styles.background),
         contentAlignment = Alignment.Center
     ) {

--- a/android/app/src/main/java/network/mysterium/provider/ui/screens/nodeui/NodeUIScreen.kt
+++ b/android/app/src/main/java/network/mysterium/provider/ui/screens/nodeui/NodeUIScreen.kt
@@ -1,10 +1,18 @@
 package network.mysterium.provider.ui.screens.nodeui
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import network.mysterium.provider.ui.components.buttons.HomeButton
 import network.mysterium.provider.ui.components.buttons.SettingsButton
@@ -23,7 +31,7 @@ fun NodeUIScreen(
 ) {
     val state by viewModel.uiState.collectAsState()
 
-    LaunchedEffect(key1 = Unit ) {
+    LaunchedEffect(key1 = Unit) {
         viewModel.trackNodeUiOpened()
     }
     NodeUIScreenContent(
@@ -41,7 +49,11 @@ private fun NodeUIScreenContent(
     onEvent: (NodeUI.Event) -> Unit,
     onNavigate: (NavigationDestination) -> Unit
 ) {
+
     LogoScreenContent(
+        modifier = Modifier
+            .statusBarsPadding()
+            .navigationBarsPadding(),
         navLeading = {
             if (state.isRegistered) {
                 HomeButton {

--- a/android/app/src/main/java/network/mysterium/provider/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/network/mysterium/provider/ui/screens/settings/SettingsScreen.kt
@@ -11,9 +11,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
@@ -131,7 +135,10 @@ private fun SettingsContent(
         }
     ) {
         Column(
-            modifier = Modifier.background(color = Colors.primaryBg),
+            modifier = Modifier
+                .background(color = Colors.primaryBg)
+                .windowInsetsPadding(WindowInsets.statusBars)
+                .windowInsetsPadding(WindowInsets.navigationBars),
         ) {
             OptionsContent(
                 modifier = Modifier.weight(1f),
@@ -242,7 +249,8 @@ private fun OptionsContent(
 
         if (!isOnboarding && appVersion != null) {
             Text(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth(),
                 text = "v${appVersion}",
                 style = TextStyles.label,
                 color = Colors.grey500,

--- a/android/app/src/main/java/network/mysterium/provider/ui/screens/start/StartScreen.kt
+++ b/android/app/src/main/java/network/mysterium/provider/ui/screens/start/StartScreen.kt
@@ -4,11 +4,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -35,6 +37,8 @@ import network.mysterium.provider.ui.theme.MysteriumTheme
 import network.mysterium.provider.ui.theme.Paddings
 import network.mysterium.provider.ui.theme.TextStyles
 import org.koin.androidx.compose.getViewModel
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.statusBars
 
 @Composable
 fun StartScreen(
@@ -47,7 +51,10 @@ fun StartScreen(
         topEnd = Corners.card
     )
     Column(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.statusBars)
+            .windowInsetsPadding(WindowInsets.navigationBars),
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
         Header(

--- a/android/app/src/main/java/network/mysterium/provider/ui/screens/tac/TACScreen.kt
+++ b/android/app/src/main/java/network/mysterium/provider/ui/screens/tac/TACScreen.kt
@@ -3,8 +3,12 @@ package network.mysterium.provider.ui.screens.tac
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.IconButton
@@ -65,7 +69,10 @@ private fun TACContent(
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(30.dp)) {
             Column(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .windowInsetsPadding(WindowInsets.statusBars)
+                    .windowInsetsPadding(WindowInsets.navigationBars),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(Paddings.small)
             ) {


### PR DESCRIPTION
This pull request improves the handling of system window insets (such as status bars and navigation bars) across multiple screens in the Android app. By adding appropriate padding and insets, the UI now better respects device safe areas, providing a more polished and consistent appearance on devices with varying screen configurations.

**System window insets and UI consistency:**

* Added `.windowInsetsPadding(WindowInsets.statusBars)` and `.windowInsetsPadding(WindowInsets.navigationBars)` modifiers to major screens (`HomeScreen`, `LaunchScreen`, `SettingsScreen`, `StartScreen`, `TACScreen`) to ensure content is not obscured by system UI elements. [[1]](diffhunk://#diff-3dd4526792ddd7945c12c47a126bab8f8f3894a89dd5a7bfc08a8cddbd0c4d6aR65-R67) [[2]](diffhunk://#diff-db771c81cfa7c0eab6ee40f68e325b9bbc36341adefe9da7dc7de70b16633ffbR151-R152) [[3]](diffhunk://#diff-5f421154bc5fb1d8ea168df1d38f0e77a40f9ba837682f04e7035ff07367e465L134-R141) [[4]](diffhunk://#diff-eab9ce591107e47392f5e215b98c64888c1d5e70e4e17b2cfe7b8773284eb546L50-R57) [[5]](diffhunk://#diff-6eafaf370b174248b1be5bbae21548a7ac104effbc88cfbccc597207766687c5L68-R75)
* Updated `NodeUIScreen` to use `.statusBarsPadding()` and `.navigationBarsPadding()` for improved inset handling.

**Imports and supporting changes:**

* Added necessary imports for `WindowInsets`, `statusBars`, `navigationBars`, and related Compose layout functions across affected files to support the new insets logic. [[1]](diffhunk://#diff-3dd4526792ddd7945c12c47a126bab8f8f3894a89dd5a7bfc08a8cddbd0c4d6aR11-R18) [[2]](diffhunk://#diff-db771c81cfa7c0eab6ee40f68e325b9bbc36341adefe9da7dc7de70b16633ffbR18-R23) [[3]](diffhunk://#diff-9814b6188c47be241c6e5a53cb8b9d3c3160f153dae31bdba24b836563d48aa8R3-R15) [[4]](diffhunk://#diff-5f421154bc5fb1d8ea168df1d38f0e77a40f9ba837682f04e7035ff07367e465R14-R20) [[5]](diffhunk://#diff-eab9ce591107e47392f5e215b98c64888c1d5e70e4e17b2cfe7b8773284eb546R7-R13) [[6]](diffhunk://#diff-eab9ce591107e47392f5e215b98c64888c1d5e70e4e17b2cfe7b8773284eb546R40-R41) [[7]](diffhunk://#diff-6eafaf370b174248b1be5bbae21548a7ac104effbc88cfbccc597207766687c5R6-R11)

**Edge-to-edge support:**

* Enabled edge-to-edge mode in `MainActivity` by calling `enableEdgeToEdge()` during `onCreate`, further aligning the app's appearance with modern Android design guidelines. [[1]](diffhunk://#diff-b8fb9c5f18039f8327ff92598f02a5191ea987926b216e22f7b986c2b8452d44R6-R12) [[2]](diffhunk://#diff-b8fb9c5f18039f8327ff92598f02a5191ea987926b216e22f7b986c2b8452d44R26)

**Minor code cleanups:**

* Reformatted some function calls for better readability, particularly around launching intents for battery optimization. [[1]](diffhunk://#diff-db771c81cfa7c0eab6ee40f68e325b9bbc36341adefe9da7dc7de70b16633ffbL66-R71) [[2]](diffhunk://#diff-db771c81cfa7c0eab6ee40f68e325b9bbc36341adefe9da7dc7de70b16633ffbL83-R89) [[3]](diffhunk://#diff-db771c81cfa7c0eab6ee40f68e325b9bbc36341adefe9da7dc7de70b16633ffbL109-R116)
* Minor modifier reformatting for improved code style.

These changes collectively enhance the user experience by ensuring the app's UI elements are displayed correctly regardless of device or system UI overlays.Applied status bar and navigation bar insets using windowInsetsPadding or padding modifiers to HomeScreen, LaunchScreen, NodeUIScreen, SettingsScreen, StartScreen, and TACScreen. This ensures proper layout and spacing on devices with system bars, improving UI consistency and edge-to-edge support. Also enabled edge-to-edge mode in MainActivity.